### PR TITLE
CLI bugfix: selector no longer has performance metric as property

### DIFF
--- a/asf/cli/cli_train.py
+++ b/asf/cli/cli_train.py
@@ -38,7 +38,7 @@ def parser_function() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--selector",
-        choices=selectors.__implemented__,
+        choices=selectors.__all__,
         required=True,
         help="Selector to train",
     )


### PR DESCRIPTION
Legacy property in CLI (performance metric) that was not being used is now also removed from the command (and command builder). This is currently broken in the release so a minor release after merge would be most welcome!